### PR TITLE
upgrade toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/act3
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc


### PR DESCRIPTION
## Summary
- upgrade the Go toolchain from 1.26.1 to 1.26.2